### PR TITLE
Added code to assertlist_cleanup to use the min between varname lengt…

### DIFF
--- a/assertlist.ado
+++ b/assertlist.ado
@@ -1,4 +1,4 @@
-*! assertlist version 2.05 - Mary Kay Trimner & Dale Rhoda - 2018-09-27
+*! assertlist version 2.06 - Mary Kay Trimner & Dale Rhoda - 2018-10-04
 *******************************************************************************
 * Change log
 * 				Updated
@@ -22,6 +22,7 @@
 *											Adjusted local in replace statement to
 *											pull first 3 characters from the full var type
 * 2018-09-27	2.05	MK Trimner			Added sheet name to Summary tab note
+* 2018-10-04	2.06	MK Trimner			Changed the str## in post file to reflect max length of 2045
 *******************************************************************************
 *
 * Contact Dale Rhoda (Dale.Rhoda@biostatglobal.com) with comments & suggestions.
@@ -421,10 +422,10 @@ program define write_xl_summary
 		* Create a log file that will be used to capture how many passed 
 		* and failed each assertion
 		postfile `handle' _al_check_sequence ///
-			str135 _al_assertion_syntax ///
-			str135 _al_tag                   ///
+			str2045 _al_assertion_syntax ///
+			str2045 _al_tag                   ///
 			_al_total _al_number_passed _al_number_failed ///
-			str150 _al_note1 using "`results'"
+			str2045 _al_note1 using "`results'"
 		
 		* Count how many passed and failed the logical statement
 		* noi di as text "Counting # that passed & failed the assertion..."

--- a/assertlist_cleanup.ado
+++ b/assertlist_cleanup.ado
@@ -1,4 +1,4 @@
-*! assertlist_cleanup version 1.04 - Biostat Global Consulting - 2018-09-13
+*! assertlist_cleanup version 1.06 - Biostat Global Consulting - 2018-10-04
 
 * This program can be used after assertlist to cleanup the column
 * names and make them more user friendly
@@ -16,6 +16,10 @@
 *										Had to add code to create a temp string variable as well
 *										in rename program
 * 2018-09-27	1.05	MK Trimner		Added code to string .xls or .xlsx extension from NAME
+* 2018-10-04	1.06	MK Trimner		Added a min of 30 for column width to prevent errors with 
+*										column widths that are too long
+* 										Also added txtwrap for entire sheet after all other formatting
+*										is completed.
 *******************************************************************************
 *
 * Contact Dale Rhoda (Dale.Rhoda@biostatglobal.com) with comments & suggestions.
@@ -75,6 +79,9 @@ program define assertlist_cleanup
 			noi di as text "Importing excel sheet: `sheet'..."
 			import excel "`excel'.xlsx", sheet("`sheet'") firstrow clear allstring
 			
+			* Create a local with the cell range for sheet
+			local range `=r(range_`b')'
+				
 			* Set local for max number of vars checked
 			local max 0
 			
@@ -105,10 +112,13 @@ program define assertlist_cleanup
 				assertlist_cleanup_rename, excel(`excel') sheet(`sheet') n(`n') max(`max') var(`v')
 				
 				* Format the tabs
-				assertlist_cleanup_format, excel(`excel') sheet(`sheet') n(`n') m1(`m`n'1') m2(`m`n'2')
+				assertlist_cleanup_format, excel(`excel') sheet(`sheet') n(`n') m1(`m`n'1') m2(`m`n'2') 
 				
 				local ++n
 			}
+			
+		* Wrap text
+		putexcel (`range'), txtwrap
 		}
 	}
 
@@ -362,13 +372,10 @@ syntax  , EXCEL(string asis) SHEET(string asis) N(int) M1(int) M2(int)
 		mata: b.set_mode("open")
 		
 		mata: b.set_sheet("`sheet'")
-
-		mata: b.set_column_width(`n',`n',`=`m1'+3')
 		
-		if `m2'>`m1' {
-			mata: b.set_column_width(`n',`n',`=`m1'+ 11')
-		}
-		
+		if `m2'>`m1'	mata: b.set_column_width(`n',`n',`=min(30,`=`m1'+ 11')')
+		else 			mata: b.set_column_width(`n',`n',`=min(30,`=`m1'+3')')
+				
 		mata b.close_book()		
 	}
 end


### PR DESCRIPTION
…h, max var value and default 30 as column width. Changed assertlist post lengths to be max string length so assertions are not cut off.