### PR TITLE
Added multiple changes. updated demo, changed assertlist replace to a…

### DIFF
--- a/assertlist demo.do
+++ b/assertlist demo.do
@@ -3,6 +3,8 @@
 * March 31, 2021
 
 * Make sure you are cd in the location you want to run your test as does create output.
+* cd "<...ADD OUTPUT PATH HERE...>"
+
 ********************************************************************************
 * Multiple excel and .do files are created during this demo.
 * We want to first wipe out any that may already be existing in the current directory
@@ -58,18 +60,19 @@ assertlist !missing(rep78), list(price mpg rep78 headroom trunk foreign) idlist(
 * If you would like to save the list of contradictions, use the excel option
 
 * With no list option, the line numbers of rows that fail assertion are exported
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_correct) 
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_correct) format
 
 * With no list option, the line numbers of rows that fail assertion are exported
-* But also add noformat option. This may speed up the Stata run and avoid excel formatting errors if spreadsheet is too large
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_to_correct) noformat
+* But also do not specify format option. This may speed up the Stata run and avoid excel formatting errors if spreadsheet is too large
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_to_correct) 
 
 * Now we want to add to this tab, but pass through additional variables
 * To do this with the non-fix option the idlist must be there same
 * Here we are defaulting to the original _al_ob_number
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_correct) list(make rep78)
-* Show with nonformat option
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_to_correct) list(make rep78) noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_correct) list(make rep78) format
+
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_to_correct) list(make rep78) 
 
 * In this case we list the make and the value of rep78, and we include an informative tag
 * This will add the new variables to the far right of the tab
@@ -85,10 +88,10 @@ assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_t
 * assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_fix) list(make rep78) tag(Missing value for rep78)
 
 * But if we add the FIX option.. the SHEET name can include FIX in it
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_fix) fix idlist(make price) checklist(rep78) tag(Missing value for rep78)
-* Show with noFormat option
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_to_fix) fix idlist(make price) checklist(rep78) tag(Missing value for rep78) noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(do_not_want_to_fix) fix idlist(make price) checklist(rep78) tag(Missing value for rep78) format
 
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_to_fix) fix idlist(make price) checklist(rep78) tag(Missing value for rep78) 
 
 * If we want to be able to go back and put in a corrected value specify the FIX
 * This creates extra spreadsheet columns for all variables provided in CHECKLIST
@@ -96,9 +99,9 @@ assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(do_not_want_t
 
 * If the user populates these columns with the correct value they can use the ASSERTLIST_REPLACE program
 * to read in these values and make the replacements.
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct) fix idlist(make) checklist(rep78) tag(Missing value for rep78)
-* Show with noFormat option
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_correct) fix idlist(make) checklist(rep78) tag(Missing value for rep78) noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct) fix idlist(make) checklist(rep78) tag(Missing value for rep78) format
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_correct) fix idlist(make) checklist(rep78) tag(Missing value for rep78) 
 
 
 * Lets the first fix test above but add a second variable to IDLIST.
@@ -110,29 +113,29 @@ assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_corre
 * assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct) fix idlist(make) checklist(rep78) tag(Missing value for rep78) list(price mpg)
 
 * Rerun with a new tab
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct_with_list) fix idlist(make) checklist(rep78) tag(Missing value for rep78) list(price mpg)
-* Show with noFormat option
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_correct_with_list) fix idlist(make) checklist(rep78) tag(Missing value for rep78) list(price mpg) noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct_with_list) fix idlist(make) checklist(rep78) tag(Missing value for rep78) list(price mpg) format
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_correct_with_list) fix idlist(make) checklist(rep78) tag(Missing value for rep78) list(price mpg)
 
 * So we can rerun this by either changing the SHEETNAME or IDLIST
 * In this case we will change the SHEETNAME
 * The sheet will include "_fix" at the end
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct2) fix idlist(make price) checklist(rep78) tag(Missing value for rep78)
-* Show with noFormat option 
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_correct2) fix idlist(make price) checklist(rep78) tag(Missing value for rep78) noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(want_to_correct2) fix idlist(make price) checklist(rep78) tag(Missing value for rep78) format
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(want_to_correct2) fix idlist(make price) checklist(rep78) tag(Missing value for rep78) 
 
 
 * If sheet is not provided, then the program will use the assertion number for the sheetname
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) list(make price rep78) tag(Missing value for rep78)
-* Show with noFormat option 
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) list(make price rep78) tag(Missing value for rep78) noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) list(make price rep78) tag(Missing value for rep78) format
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) list(make price rep78) tag(Missing value for rep78) 
 
 * If sheet is not provided, then the program will use the assertion number for the sheetname
 * When fix is specified, suffix _fix will be added
 * We will also list gear ratio
-assertlist !missing(rep78), excel(al_xl_demo.xlsx) idlist(make price) check(rep78) list(gear_ratio) tag(Missing value for rep78) fix
-* Show with noFormat option 
-assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) idlist(make price) check(rep78) list(gear_ratio) tag(Missing value for rep78) fix noformat
+assertlist !missing(rep78), excel(al_xl_demo.xlsx) idlist(make price) check(rep78) list(gear_ratio) tag(Missing value for rep78) fix format
+* Show without specifying format option
+assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) idlist(make price) check(rep78) list(gear_ratio) tag(Missing value for rep78) fix
 * Now we will rerun this with formatting to show what happens if you add formatting to an unformatted sheet
 * the Summary tab will be formatted and so will tab 8_fix
 //assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) sheet(8) idlist(make price) check(rep78) list(gear_ratio) tag(Missing value for rep78) fix 
@@ -142,13 +145,13 @@ assertlist !missing(rep78), excel(al_xl_demo_no_format.xlsx) idlist(make price) 
 * Assertions where all lines pass
 
 * If excel is not specified... nothing happens as all lines passed the assertion
-assertlist gear_ratio < 4, list(make gear_ratio)
+assertlist gear_ratio < 4, list(make gear_ratio) format
 
 * When Excel is specified
 * Note that the program makes an entry in the Assertlist_Summary sheet, but does 
 * not make a new sheet named 'no_fails' or no_fails_fix
-assertlist inlist(foreign,1,0), excel(al_xl_demo.xlsx) sheet(no_fails) list(make foreign)
-assertlist gear_ratio < 4, excel(al_xl_demo.xlsx) sheet(no_fails) fix idlist(make) checklist(gear_ratio) list(foreign) tag(Gear ratio higher than expected)
+assertlist inlist(foreign,1,0), excel(al_xl_demo.xlsx) sheet(no_fails) list(make foreign) format
+assertlist gear_ratio < 4, excel(al_xl_demo.xlsx) sheet(no_fails) fix idlist(make) checklist(gear_ratio) list(foreign) tag(Gear ratio higher than expected) format
 ********************************************************************************
 * Let's look at an assertion involving an 'if' statement 
 assertlist headroom <= 3 if length <= 180, list(make headroom length)
@@ -158,15 +161,14 @@ assertlist headroom <= 3 if length <= 180, list(make headroom length)
 * will replace the value of headroom or of length, so we list BOTH in the 
 * CHECKLIST option
 * Note this will append to the existing want_to_correct_fix tab as the idlist is the same
-assertlist headroom <= 3 if length <= 180, excel(al_xl_demo.xlsx) sheet(want_to_correct) fix idlist(make) checklist(headroom length) tag(Headroom seems large for small length)
+assertlist headroom <= 3 if length <= 180, excel(al_xl_demo.xlsx) sheet(want_to_correct) fix idlist(make) checklist(headroom length) tag(Headroom seems large for small length) format
 
 * If we only want to view the variable in the IF statement we would add it to the LIST option.
 * This will ERROR out though, because we did not put it on a new sheet 
 * assertlist headroom <= 3 if length <= 180, excel(al_xl_demo.xlsx) sheet(want_to_correct) fix idlist(make) list(length) checklist(headroom) tag(Headroom seems large for small length)
 
 * Repeat with a new sheet
-assertlist headroom <= 3 if length <= 180, excel(al_xl_demo.xlsx) sheet(want_to_correct3) fix idlist(make) list(length) checklist(headroom) tag(Headroom seems large for small length)
-
+assertlist headroom <= 3 if length <= 180, excel(al_xl_demo.xlsx) sheet(want_to_correct3) fix idlist(make) list(length) checklist(headroom) tag(Headroom seems large for small length) format
 * Finally, here is an example of sending output from several assertions to a 
 * single worksheet which can be used for data cleaning.
 
@@ -176,14 +178,14 @@ assertlist headroom <= 3 if length <= 180, excel(al_xl_demo.xlsx) sheet(want_to_
 * pretend that a data manager might go back and check the large values to 
 * see whether they are correct or mis-typed.
 
-assertlist price < 15900, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(price) tag(Price seems very high) list(price rep78 gear_ratio)
-assertlist mpg < 40, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(mpg) tag(MPG seems very high) list(price rep78 gear_ratio)
-assertlist rep78 < 5 if !missing(rep78), excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(rep78) tag(rep78 seems very high) list(price rep78 gear_ratio)
-assertlist headroom < 5, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(headroom) tag(Head room seems very high) list(price rep78 gear_ratio)
-assertlist trunk < 22, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(trunk) tag(Trunk space seems very high) list(price rep78 gear_ratio)
+assertlist price < 15900, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(price) tag(Price seems very high) list(price rep78 gear_ratio) format
+assertlist mpg < 40, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(mpg) tag(MPG seems very high) list(price rep78 gear_ratio) format
+assertlist rep78 < 5 if !missing(rep78), excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(rep78) tag(rep78 seems very high) list(price rep78 gear_ratio) format
+assertlist headroom < 5, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(headroom) tag(Head room seems very high) list(price rep78 gear_ratio) format
+assertlist trunk < 22, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(trunk) tag(Trunk space seems very high) list(price rep78 gear_ratio) format
 
 * Add a test with a second check variable... This will create var_2* variables
-assertlist trunk < 22, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(trunk mpg) tag(Trunk space seems very high) list(price rep78 gear_ratio)
+assertlist trunk < 22, excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(trunk mpg) tag(Trunk space seems very high) list(price rep78 gear_ratio) format
 
 * Add check for missing rep78 so we can add some conflicts
 assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(rep78) tag(rep78 missing) list(price rep78 gear_ratio)
@@ -191,7 +193,6 @@ assertlist !missing(rep78), excel(al_xl_demo.xlsx) sheet(several_tests) fix idli
 * Add check for test string that will be used to show how to make a string missing in replace program
 assertlist test1 == "", excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(test1 test2) tag(Test1 should be missing) list(price rep78 gear_ratio)
 assertlist test2 == . , excel(al_xl_demo.xlsx) sheet(several_tests) fix idlist(make) checklist(test2 test1) tag(Test2 should be missing) list(price rep78 gear_ratio)
-
 * Note that if you sort the output by 'make',
 * the VW Diesel appears twice in the list; it has extreme values 
 * for two of the variables we checked.  So if we went back to VW to 
@@ -213,9 +214,9 @@ copy "al_xl_demo_no_format.xlsx" "al_xl_demo_no_format_not_cleaned.xlsx", replac
 * Now we will run the program to grab all the ids from each tab and put them in 1 tab
 * Users can opt to create a new excel file or add it to the existing excel file.
 * This will run the spreadsheet that has not been cleaned first.
-assertlist_export_ids, excel(al_xl_demo)
-* Show with noFORMAT option 
-assertlist_export_ids, excel(al_xl_demo_no_format) noformat
+assertlist_export_ids, excel(al_xl_demo) format
+* Show without FORMAT option 
+assertlist_export_ids, excel(al_xl_demo_no_format) 
  ********************************************************************************
 * Once you have completed all potential assertions and BEFORE
 * going back to the source to check the data, you can run the 
@@ -224,32 +225,32 @@ assertlist_export_ids, excel(al_xl_demo_no_format) noformat
 * The first time through we will specify the required EXCEL option
 * and optional NAME to preserve the original spreadsheet.
 * This sheet has an ID tab
-assertlist_cleanup, excel(al_xl_demo.xlsx) name(al_xl_demo_clean.xlsx)
-* Show with noFORMAT option 
-assertlist_cleanup, excel(al_xl_demo_no_format.xlsx) name(al_xl_demo_clean_no_format.xlsx) noformat
+assertlist_cleanup, excel(al_xl_demo.xlsx) name(al_xl_demo_clean.xlsx) format
+* Show without FORMAT option 
+assertlist_cleanup, excel(al_xl_demo_no_format.xlsx) name(al_xl_demo_clean_no_format.xlsx) 
 
 * Next we will also specify the optional IDSORT option so that all sheets are
 * sorted by the IDLIST provided in the original assertion. 
 * This automatically does the sort by `make' mentioned above.
 
-assertlist_cleanup, excel(al_xl_demo_org.xlsx) name(al_xl_demo_clean_and_sorted.xlsx) idsort
-* Show with noFORMAT option 
-assertlist_cleanup, excel(al_xl_demo_no_format_org.xlsx) name(al_xl_demo_clean_and_sorted_no_format.xlsx) idsort noformat
+assertlist_cleanup, excel(al_xl_demo_org.xlsx) name(al_xl_demo_clean_and_sorted.xlsx) idsort format
+* Show without FORMAT option 
+assertlist_cleanup, excel(al_xl_demo_no_format_org.xlsx) name(al_xl_demo_clean_and_sorted_no_format.xlsx) idsort 
 
 * Lastly we will only specify the required EXCEL option.
 * This will overwrite the original EXCEL file with the cleaned up sheets.
 * so we can show how assertlist_replace can be used on either EXCEL files.
 * This also shows how the ID tab will be cleaned up 
-assertlist_cleanup, excel(al_xl_demo.xlsx)
-* Show with noFORMAT option
-assertlist_cleanup, excel(al_xl_demo_no_format.xlsx) noformat
+assertlist_cleanup, excel(al_xl_demo.xlsx) format
+* Show without FORMAT option 
+assertlist_cleanup, excel(al_xl_demo_no_format.xlsx) 
 
  ********************************************************************************
 * Run the assertlist_export_ids on a cleaned dataset
 * This will also add the cleaned up headers to the new ID tab
-assertlist_export_ids, excel(al_xl_demo_clean_and_sorted.xlsx)
-* Show with noFORMAT option 
-assertlist_export_ids, excel(al_xl_demo_clean_and_sorted.xlsx) noformat
+assertlist_export_ids, excel(al_xl_demo_clean_and_sorted.xlsx) format
+* Show without FORMAT option 
+assertlist_export_ids, excel(al_xl_demo_clean_and_sorted.xlsx) 
 
 ********************************************************************************
 * To show an example of assertlist_replace we will need to add some values to 
@@ -271,50 +272,103 @@ foreach v in al_xl_demo_org al_xl_demo_clean al_xl_demo_not_cleaned {
 	putexcel set "`v'.xlsx", modify sheet("want_to_correct_fix")	
 	
 	* Add replacement values for var 1
-	putexcel I2 = 4, nformat(#)
-	putexcel I3 = 2, nformat(#)
-	putexcel I4 = 3, nformat(#)
-	putexcel I5 = 4, nformat(#)
-	putexcel I6 = 4, nformat(#)
-	putexcel I7 = 3.5, nformat(#.#)
+	putexcel J2 = 4, nformat(#) // Conflict with several_tests_fix tab ... Duplicate with want_to_correct_with_list_fix tab... Will show up in Conflict portion of .do file
+	putexcel J3 = 2, nformat(#) // Conflict with several_tests_fix tab and want_to_correct_with_list_fix tab 
+	putexcel J4 = 3, nformat(#) // Duplicate with several_tests_fix tab and want_to_correct_with_list_fix tab 
+	putexcel J5 = 4, nformat(#) // Conflict from want_to_correct_with_list_fix tab 
+	putexcel J6 = 4, nformat(#) // Duplicate from want_to_correct_with_list_fix tab
+	putexcel J7 = 3.5, nformat(#.#)
 	
 	* Adding replacement values for var 2 
-	putexcel M8 = 190, nformat(#)
+	putexcel N8 = 190, nformat(#)
+		
+	* Add a replacement variable to empty rows 
+	* These will be ignored
+	
+	* This one is missing the id to make the replacement
+	putexcel J10 = "!MISSING!" // Will not be completed due to lack of information
+	putexcel G10 = "headroom"
+	
+	
+	* this one is missing the variable to make the replacement
+	putexcel J12 = 4, nformat(#) // Will not be completed due to lack of information
+	putexcel D12 = "Subaru"
+	
+	* add a replacement variable to empty rows that has identifiers and variable
+	* This will be processed as it has all the required information
+	putexcel J14 = 4, nformat(#)
+	putexcel D14 = "Dodge Diplomat"
+	putexcel G14 = "headroom"
+
 	putexcel close
-	 
-	 
+	
+	
+	
+	putexcel set "`v'.xlsx", modify sheet("want_to_correct_with_list_fix")	
+	
+	* Add replacement values for var 1
+	putexcel L2 = 4, nformat(#) // Duplicate with want_to_correct_fix ... Conflict with several_tests_fix... Will show up in the Conflict portion of the .do file
+	putexcel L3 = 5, nformat(#) // Conflict with want_to_correct_fix tab and several_tests_fix tab 
+	putexcel L4 = 3, nformat(#) // Duplicate with several_tests_fix tab and want_to_correct_fix tab 
+	putexcel L5 = 1, nformat(#) // Conflict from want_to_correct_fix tab 
+	putexcel L6 = 4, nformat(#) // Duplicate from want_to_correct_fix tab
+	
+	* Add a replacement variable to empty rows 
+	* These will be ignored because it is missing the Var name and ID
+	putexcel L8 = 2, nformat(#)
+
+	putexcel close
+
 	putexcel set "`v'.xlsx", modify sheet("several_tests_fix")
 	* Add replacement values for var 1
-	putexcel L4 = 2, nformat(#)
-	putexcel L2= 15900, nformat(#)
-	putexcel L5 = 3, nformat(#)
-	putexcel L6 = 1, nformat(#)
-	putexcel L7 = 4, nformat(#)
-	putexcel L8 = 4, nformat(#)
-	putexcel L9 = 2, nformat(#)
-	putexcel L10 = 2, nformat(#)
-	putexcel L11 = 1, nformat(#)
-	putexcel L12 = 1, nformat(#)
-	putexcel L13 = 3 , nformat(#)
-	putexcel L14 = 4, nformat(#)
-	putexcel L20 = 3, nformat(#) // conflict from other tab
-	putexcel L21 = 2, nformat(#) // same as other tab
-	putexcel L22 = 5, nformat(#) //conflict from other tab
-	putexcel L23 = 1, nformat(#) //conflict from other tab
-	putexcel L24 = 4, nformat(#) // same as other tab
-	putexcel L25 = "!MISSING!"
-	putexcel L26 = "!MISSING!"
-	putexcel L27 = "!MISSING!"
-	putexcel L28 = "!MISSING!" 
-	putexcel L29 = "!MISSING!"
-	putexcel P25 = "!MISSING!" // Creates duplicate within tab
-	putexcel P26 = "!MISSING!"
-	putexcel P27 = "!MISSING!"
-	putexcel P28 = "!MISSING!" // Creates duplicate within tab
-	putexcel P29 = "!MISSING!"
+	
+	* these first sets will be processed as is
+	putexcel M2= 15900, nformat(#)
+	putexcel M3= 35, nformat(#)
+	
+	putexcel M4 = 2, nformat(#)
+	putexcel M5 = 3, nformat(#)
+	putexcel M6 = 1, nformat(#)
+	putexcel M7 = 4, nformat(#)
+	putexcel M8 = 4, nformat(#)
+	putexcel M9 = 2, nformat(#)
+	putexcel M10 = 2, nformat(#)
+	putexcel M11 = 1, nformat(#)
+	putexcel M12 = 1, nformat(#)
+	putexcel M13 = 3 , nformat(#)
+	putexcel M14 = 4, nformat(#)
+	
+	
+	putexcel M15 = 3, nformat(#) 
+	
+	
+	putexcel M16 = 21, nformat(#) // 1 Conflict on same tab
+	putexcel M17 = 15, nformat(#) // 1 Conflict on same tab
+	putexcel M18 = 11, nformat(#) // 1 Conflict on same tab
+	putexcel M19 = 14, nformat(#) // 1 Conflict on same tab
+	
+	* Now add replacement values for var 1
+	putexcel M20 = "!MISSING!" // Conflict with want_to_correct_fix & want_to_correct_with_list_fix tabs
+	putexcel M21 = "!MISSING!" // Conflict with want_to_correct_fix & want_to_correct_with_list_fix tabs
+	putexcel M22 =  3, nformat(#) // Duplicate with want_to_correct_with_list_fix tab and want_to_correct_fix tab
+	putexcel M24 = "!MISSING!" // Creates duplicate on same tab
+	putexcel M25 = "!MISSING!"
+	putexcel M26 = "!MISSING!" // Creates duplicate on same tab
+	putexcel M27 = "!MISSING!" 
 	
 	* Add replacement values for var 2
 	putexcel P18 = 14, nformat(#)
+	putexcel Q24 = "!MISSING!" // Creates duplicate on same tab
+	putexcel Q25 = "!MISSING!"
+	putexcel Q26 = "!MISSING!" // Creates duplicate on same tab
+	putexcel Q27 = "!MISSING!" 
+	
+	
+	* Add a replacement variable to empty rows 
+	* These will be ignored
+	putexcel M28 = 2, nformat(#)
+	putexcel Q29 = "!MISSING!" 
+
 	putexcel close
 }
 
@@ -350,7 +404,3 @@ assertlist_replace, excel(al_xl_demo_clean) dofile(al_xl_demo_clean_replace_comm
 assertlist_replace, excel(al_xl_demo_clean) dofile(al_xl_demo_clean_replace_commands_with_comment) ///
 	reviewer(NAME HERE) date(2020-03-20) dataset1(auto) dataset2(auto_replace) ///
 	comments(These values were selected at random for example purposes and the changes should not be implemented in the auto dataset.)
-	
-
-
-	

--- a/assertlist.sthlp
+++ b/assertlist.sthlp
@@ -22,7 +22,7 @@
 		  {it:{help assertlist##fix:FIX}}
 		  {it:{help assertlist##idlist:IDlist}}(varlist) 
 		  {it:{help assertlist##checklist:CHECKlist}}(varlist)
-		  {it:{help assertlist##noformat:noFORMAT}}
+		  {it:{help assertlist##format:FORMAT}}
  ] {p_end}
 
 {synoptline}
@@ -222,12 +222,13 @@
 		{bf:local macro and list the macro in the IDlist or CHECKlist options.}
 		{p_end}
 
-{marker noformat}
-{pstd} {bf:noFORMAT} - {cmd:assertlist} defaults to format columns with text, color and width options making the spreadsheet easy for the user to read. When {cmd:noformat} is specified all Excel formatting commands are ignored. 
+{marker format}
+{pstd} {bf:FORMAT} - {cmd:assertlist} defaults to unformatted columns. 
+When {cmd:format} is specified the file will be formatted with text, color and width options making the spreadsheet easy for the user to read.  
 This enables the user to run Stata faster and avoid potential Excel formatting errors due to large spreadsheets. {p_end}
 
 {pmore2} {bf:NOTE: If a SHEET is formatted during a prior {help assertlist} run this formatting will not be undone.}
-{bf:The same is true if a later run sends output to the same SHEET and does not specify {it:noformat}, assertlist will {it:ADD} formatting to that sheet.} {p_end}
+{bf:The same is true if a later run sends output to the same SHEET and specifies {it:format}, assertlist will {it:ADD} formatting to that sheet.} {p_end}
 
 {hline}
 

--- a/assertlist_cleanup.sthlp
+++ b/assertlist_cleanup.sthlp
@@ -13,7 +13,7 @@
 {title:Syntax}
 {p 8 16 2}
 {opt assertlist_cleanup}{cmd:,}   {it:{help assertlist_cleanup##excel:EXCEL}}(string) [ {it:{help assertlist_cleanup##name:NAME}}(string)
-{it:{help assertlist_cleanup##idsort:IDSORT}} {it:{help assertlist_cleanup##noformat:noFORMAT}}]
+{it:{help assertlist_cleanup##idsort:IDSORT}} {it:{help assertlist_cleanup##format:FORMAT}}]
 {p_end}
 
 {synoptline}
@@ -57,11 +57,12 @@
 {marker idsort}
 {pstd} {bf:IDSORT} - Sorts each tab by the list of variables that uniquely identify each observation. These variables were provided in the {help assertlist##idlist:IDLIST} option in the original {cmd:assertlist} command.	{p_end}
 
-{marker noformat}
-{pstd} {bf:noFORMAT} - {cmd:assertlist_cleanup} defaults to format columns with text, color and width options making the spreadsheet easy for the user to read. When {cmd:noformat} is specified all Excel formatting commands are ignored. 
+{marker format}
+{pstd} {bf:FORMAT} - {cmd:assertlist_cleanup} defaults to unformatted columns. 
+When {cmd:format} is specified the file will be formatted with text, color and width options making the spreadsheet easy for the user to read. 
 This enables the user to run Stata faster and avoid potential Excel formatting errors due to large spreadsheets. {p_end}
 
-{pmore2} {bf:NOTE: If a tab was already formatted during the {help assertlist} run this formatting will not be undone. This option only ensures that this run will not add any formatting to the spreadsheet.} {p_end}
+{pmore2} {bf:NOTE: If a tab was already formatted during the {help assertlist} run this formatting will not be undone. If not specified this option only ensures that this run will not add any formatting to the spreadsheet.} {p_end}
 
 {title: Column Name Change Details}
 {pstd} The list below enumerates the column name changes that are completed by {cmd:ASSERTLIST_CLEANUP}. All other column names remain the same. {p_end}

--- a/assertlist_export_ids.sthlp
+++ b/assertlist_export_ids.sthlp
@@ -12,7 +12,7 @@
 {marker syntax}{...}
 {title:Syntax}
 {p 8 16 2}
-{opt assertlist_export_ids}{cmd:,}   {it:{help assertlist_export_ids##excel:EXCEL}}(string) [{it:{help assertlist_export_ids##noformat:noFORMAT}}]
+{opt assertlist_export_ids}{cmd:,}   {it:{help assertlist_export_ids##excel:EXCEL}}(string) [{it:{help assertlist_export_ids##format:FORMAT}}]
 {p_end}
 
 {synoptline}
@@ -45,8 +45,9 @@
         {bf: path and file name. Do {it:NOT} include double quotes around the path and filename for output Excel file.}{p_end}
 
 {title:Optional Input} 
-{marker noformat}
-{pstd} {bf:noFORMAT} - {cmd:assertlist_export_ids} defaults to format columns with text, color and width options making the spreadsheet easy for the user to read. When {cmd:noformat} is specified all Excel formatting commands are ignored. 
+{marker format}
+{pstd} {bf:FORMAT} - {cmd:assertlist_export_ids} defaults to unformatted columns. 
+When {cmd:format} is specified the file will be formatted with text, color and width options making the spreadsheet easy for the user to read.
 This enables the user to run Stata faster and avoid potential Excel formatting errors due to large spreadsheets. 
 
 {title:Output}


### PR DESCRIPTION
…lign with assertlist changes.

assert list changes 
* 2022-03-29								Made it so that variable _al_obs_number is always part of IDLIST
*											to help identify failed assertions across dataset. This will not be put out in the summary tab IDLIST unless no other variables were specified in IDLIST 
* 2022-04-12	2.21	MK Trimner			Removed di of list from previous change debug process
* 2023-01-31	2.22	MK Trimner			changed from noFormat to just Format. This is more logical
*											Changed formatting to use formatids when
*											using stata version >=15 			
* 2024-03-20	2.23	MK Trimner			Updated the row value if sheet exists to remove blank rows	


assertlit cleanup changes: 
* 2023-01-31	1.17	MK Trimner		Changed the noFORMAT option to be FORMAT. the default will now be to not format. 
*										Added fmtids when using stata version >= 15

assertlist export id changes:
* 2023-01-29	1.05	MK TRimner		Changed noFORMAT to FORMAT. it is more logical. The default now is to not format. 
*										Added fmtids if using stata version >=15
* 2024-03-20	1.06	MK trimner		Added code to only keep the _al_* variables

assertlist replace changes:
* 2024-03-28	1.07	MK Trimner		Updated to align with changes made to assertlist
* 										Put out to do file any rows without identifiers that will be ignored , added the ability to add new rows that were not included in the original assertions