### PR TITLE
Changes to simplify the formatting 

### DIFF
--- a/assertlist.ado
+++ b/assertlist.ado
@@ -398,7 +398,8 @@ syntax [, KEEP(varlist) LIST(varlist) IDlist(varlist) CHECKlist(varlist) ///
 				
 				* grab the row number to know where we need to export to
 				* Add 1 to go to the next row
-				local row `=r(N) + 1'
+				local row `=r(N) + 2'
+				noi di "`row'"
 				
 				* Grab the original varlist from sheet
 				* This will help you confirm if the new vars match the old

--- a/assertlist_cleanup.ado
+++ b/assertlist_cleanup.ado
@@ -49,6 +49,7 @@
 *										Added simplify option to hide things in the Assertlist_Summary tab
 *										Added code to highlight the cells in fix tab that should be yellow _al_correct_var_#
 *										Adjusted code to simplify formatting
+* 										
 *******************************************************************************
 *
 * Contact Dale Rhoda (Dale.Rhoda@biostatglobal.com) with comments & suggestions.
@@ -80,7 +81,7 @@ program define assertlist_cleanup
 				
 	}
 	else {
-		*preserve
+		preserve
 		
 		* Describe excel file to determine how many sheets are present
 		capture import excel using "`excel'.xlsx", describe
@@ -169,7 +170,7 @@ program define assertlist_cleanup
 				passthrough(`passthrough') hide(`hide') `simplify'  `highlight'
 			
 		} // end loop through each of the sheets
-		*restore
+		restore
 	} // end file exists loop
 
 end

--- a/assertlist_export_ids.ado
+++ b/assertlist_export_ids.ado
@@ -61,6 +61,7 @@ program define assertlist_export_ids
 		}
 		else {
 
+			preserve
 			* Now lets create a single dataset with the cards that need reviewed
 			capture import excel using "`excel'.xlsx", describe
 			local f `=r(N_worksheet)'
@@ -147,10 +148,10 @@ program define assertlist_export_ids
 							duplicates drop
 							save `assertion_ids_for_review', replace
 						}
-					}
+					} // end loop if file `data' does not exist
 					
-				}
-			}
+				} // end loop through if statement if sheet is not Assertlist_Summary or List of IDs failed assertions
+			} // end loop through all the different sheets
 		
 			noi di as text "Create one dataset..."
 			* replace tag value
@@ -174,8 +175,8 @@ program define assertlist_export_ids
 					local wc = wordcount("`w'")
 					forvalues n = 1/`wc' {
 						local uniquelist `uniquelist' `=word("`w'",`n')'
-					}
-				}
+					} // end loop through 1 - wourdcount of `w'
+				} // end loop through local list
 				local list2 : list uniq uniquelist
 				replace _al_idlist = `"`list2'"' if _al_obs_number == `i'
 				local orderlist `orderlist' `uniquelist'
@@ -192,11 +193,10 @@ program define assertlist_export_ids
 							local list2 : list uniq uniquelist
 							replace `v' = `"`list2'"' if _al_obs_number == `i'
 
-						}
-					}
-				}
-				
-			}
+						} // end loop through local list
+					} // end if != _al_obs_number
+				} // end loop through local list2
+			} // end loop through local id
 			
 			local order2 : list uniq orderlist
 			local order2 =subinstr("`order2'","_al_obs_number","",.)
@@ -255,7 +255,7 @@ program define assertlist_export_ids
 					local m`i'=min(`uselength',`maxlength')
 					drop ``v'_l'
 					local ++i
-				}
+				} // end loop through varlist *
 				
 				* Now format the excel
 				mata: b = xl()
@@ -287,7 +287,7 @@ program define assertlist_export_ids
 
 						mata: b.set_fmtid((2,`row'),`i',format_width_`m`i'')
 					}
-				}
+				} // end version formatting for 15
 				if $FORMATTING_VERSION == 14 {
 				
 					forvalues i = 1/`col' {
@@ -299,11 +299,13 @@ program define assertlist_export_ids
 					mata: b.set_fill_pattern(1,(1,`col'),"solid","lightgray")
 					mata: b.set_font_bold(1,(1,`col'),"on")
 					mata: b.set_horizontal_align(1,(1,`col'),"left")
-				}
+				} // end version formatting for 14
 				mata b.close_book()	
-			}
-		}
-	}
+			} // end formatting loop
+			restore
+		} // end if statement if the file provided does exist
+		
+	} // end qui loop
 end
 
 ********************************************************************************


### PR DESCRIPTION
Multiple changes to simplify formatting and a few other things

assertlist 
* 2026-01-21	2.24	MK Trimner			Simplified Formatting to avoid excel crashing

assertist_cleanup 
* 2026-02-11	1.19	MK Trimner		Trim down formatting to use the same formatids as previously used
*										Added keepcellfmt to export option
*										Added simplify option to hide things in the Assertlist_Summary tab
*										Added code to highlight the cells in fix tab that should be yellow _al_correct_var_#
*										Adjusted code to simplify formatting

assertlist_export_ids 
* 2026-01-21	1.07	MK Trimner		Added code to drop if missing _al_obs_number
*										Corrected code to provide the correct idlist
*										Cleaned up formatting to reduce the number of formatting ids
*										Added exclusion to not include "List of IDs failed assertions" if already created
